### PR TITLE
Set git username, email and Signed-off explicitly

### DIFF
--- a/.github/workflows/sync-support-workflows.yml
+++ b/.github/workflows/sync-support-workflows.yml
@@ -22,4 +22,6 @@ jobs:
           # This token requires workflows permissions.
           GH_PAT: ${{ secrets.BITNAMI_BOT_SUPPORT_TOKEN }}
           PR_LABELS: support
+          GIT_USERNAME: bitnami-bot
+          GIT_EMAIL: bitnami-bot@vmware.com
           COMMIT_BODY: "\n\nSigned-off-by: bitnami-bot <bitnami-bot@vmware.com>"


### PR DESCRIPTION
We have to set explicitly `GIT_EMAIL`, `GIT_USERNAME`  and the `Signed-off-by` body to pass correctly the DCO check.

More info here: https://github.com/BetaHuhn/repo-file-sync-action/discussions/123