### PR TITLE
Add cards before moving them

### DIFF
--- a/.github/workflows/comment-created.yml
+++ b/.github/workflows/comment-created.yml
@@ -25,6 +25,13 @@ jobs:
           repository: bitnami/support
       - name: Load .env file
         uses: xom9ikk/dotenv@de1ff27d319507880e6621e4d47424c677d95f68
+      - name: Add to board
+        id: add-to-project
+        uses: actions/add-to-project@0be3b6580ae2145e72e0ada85d693ab71a5f17d6
+        with:
+          # Support project
+          project-url: https://github.com/orgs/bitnami/projects/4
+          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
       - name: Move into From Build Maintenance
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
         # The comment was created by bitnami-bot in a pull_request created by bitnami-bot

--- a/.github/workflows/item-closed.yml
+++ b/.github/workflows/item-closed.yml
@@ -28,6 +28,25 @@ jobs:
           echo "author=${author}" >> $GITHUB_OUTPUT
           echo "number=${number}" >> $GITHUB_OUTPUT
           echo "type=${type}" >> $GITHUB_OUTPUT
+      - name: Solved labeling
+        # Only if moved into Solved and the issue author is not bitnami-bot
+        if: ${{ steps.get-item.outputs.author != 'bitnami-bot' }}
+        uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
+        with:
+          add-labels: solved
+          # Triage is not on the list to know how many issues/PRs are solved
+          # directly on triage
+          remove-labels: in-progress, on-hold
+      - name: Add to board
+        id: add-to-project
+        uses: actions/add-to-project@0be3b6580ae2145e72e0ada85d693ab71a5f17d6
+        if: |
+          steps.get-item.outputs.author != 'bitnami-bot' ||
+          (steps.get-item.outputs.author == 'bitnami-bot' && contains(github.event.pull_request.labels.*.name, 'review-required'))
+        with:
+          # Support project
+          project-url: https://github.com/orgs/bitnami/projects/4
+          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
       - name: Send to the Solved column
         id: send-solved
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
@@ -41,12 +60,3 @@ jobs:
           operation: set
           fields: Status
           values: Solved
-      - name: Solved labeling
-        # Only if moved into Solved and the issue author is not bitnami-bot
-        if: ${{ steps.get-item.outputs.author != 'bitnami-bot' }}
-        uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
-        with:
-          add-labels: solved
-          # Triage is not on the list to know how many issues/PRs are solved
-          # directly on triage
-          remove-labels: in-progress, on-hold

--- a/.github/workflows/item-labeled.yml
+++ b/.github/workflows/item-labeled.yml
@@ -61,6 +61,13 @@ jobs:
       github.event.action == 'labeled' && github.actor != 'bitnami-bot' &&
       contains(fromJson(needs.get-info.outputs.label-keys),github.event.label.name)
     steps:
+      - name: Add to board
+        id: add-to-project
+        uses: actions/add-to-project@0be3b6580ae2145e72e0ada85d693ab71a5f17d6
+        with:
+          # Support project
+          project-url: https://github.com/orgs/bitnami/projects/4
+          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
       - name: Add to column
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
         with:

--- a/.github/workflows/pr-review-requested-sync.yml
+++ b/.github/workflows/pr-review-requested-sync.yml
@@ -31,6 +31,14 @@ jobs:
           repository: bitnami/support
       - name: Load .env file
         uses: xom9ikk/dotenv@de1ff27d319507880e6621e4d47424c677d95f68
+      - name: Add to board
+        id: add-to-project
+        uses: actions/add-to-project@0be3b6580ae2145e72e0ada85d693ab71a5f17d6
+        if: ${{ !contains(fromJson(env.BITNAMI_TEAM), github.actor) }}
+        with:
+          # Support project
+          project-url: https://github.com/orgs/bitnami/projects/4
+          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
       - name: Move into In Progress
         # Move the card only if the actor is not a Bitnami member
         if: ${{ !contains(fromJson(env.BITNAMI_TEAM), github.actor) }}


### PR DESCRIPTION
This change will ensure cards are created at any phase. This very useful in migrations or when we are adding new repos (with issues already created) to the Project Board.