### PR TITLE
Change secret token

### DIFF
--- a/.github/workflows/comment-created.yml
+++ b/.github/workflows/comment-created.yml
@@ -5,7 +5,7 @@ name: '[Support] Comments based card movements'
 on:
   workflow_call:
     secrets:
-      BITNAMI_BOT_TOKEN:
+      BITNAMI_SUPPORT_BOARD_TOKEN:
         required: true
 # Remove all permissions by default
 permissions: {}
@@ -31,14 +31,14 @@ jobs:
         with:
           # Support project
           project-url: https://github.com/orgs/bitnami/projects/4
-          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
       - name: Move into From Build Maintenance
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
         # The comment was created by bitnami-bot in a pull_request created by bitnami-bot
         if: ${{ github.actor == 'bitnami-bot' && github.event.issue.user.login == 'bitnami-bot' && github.event.issue.pull_request != null }}
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
-          github_token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
           values: Build Maintenance
@@ -50,7 +50,7 @@ jobs:
           (!contains(github.event.issue.labels.*.name, 'bitnami'))
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
-          github_token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
           values: Pending
@@ -62,7 +62,7 @@ jobs:
           contains(github.event.issue.labels.*.name, 'in-progress')
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
-          github_token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
           values: In progress
@@ -74,7 +74,7 @@ jobs:
           (!contains(github.event.issue.labels.*.name, 'in-progress'))
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
-          github_token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
           values: Triage

--- a/.github/workflows/item-closed.yml
+++ b/.github/workflows/item-closed.yml
@@ -5,7 +5,7 @@ name: '[Support] Move closed issues'
 on:
   workflow_call:
     secrets:
-      BITNAMI_BOT_TOKEN:
+      BITNAMI_SUPPORT_BOARD_TOKEN:
         required: true
 # Remove all permissions by default. Actions are performed by Bitnami Bot
 permissions: {}
@@ -46,7 +46,7 @@ jobs:
         with:
           # Support project
           project-url: https://github.com/orgs/bitnami/projects/4
-          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
       - name: Send to the Solved column
         id: send-solved
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
@@ -56,7 +56,7 @@ jobs:
           (steps.get-item.outputs.author == 'bitnami-bot' && contains(github.event.pull_request.labels.*.name, 'review-required'))
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
-          github_token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
           values: Solved

--- a/.github/workflows/item-labeled.yml
+++ b/.github/workflows/item-labeled.yml
@@ -6,7 +6,7 @@ name: '[Support] Reasign tasks'
 on:
   workflow_call:
     secrets:
-      BITNAMI_BOT_TOKEN:
+      BITNAMI_SUPPORT_BOARD_TOKEN:
         required: true
 # Remove all permissions by default
 permissions: {}
@@ -35,7 +35,7 @@ jobs:
       - id: get-info
         name: Get label mapping
         env:
-          GITHUB_TOKEN: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
         run: |
           author="${{ github.event.issue != null && github.event.issue.user.login || github.event.pull_request.user.login }}"
           repo_name="${{ github.event.repository.name }}"
@@ -67,12 +67,12 @@ jobs:
         with:
           # Support project
           project-url: https://github.com/orgs/bitnami/projects/4
-          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
       - name: Add to column
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
-          github_token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
           values: ${{ fromJson(needs.get-info.outputs.label-mapping)[github.event.label.name].column }}

--- a/.github/workflows/item-opened.yml
+++ b/.github/workflows/item-opened.yml
@@ -6,7 +6,7 @@ name: '[Support] Organize triage'
 on:
   workflow_call:
     secrets:
-      BITNAMI_BOT_TOKEN:
+      BITNAMI_SUPPORT_BOARD_TOKEN:
         required: true
 # Remove all permissions by default
 permissions: {}
@@ -45,13 +45,13 @@ jobs:
         with:
           # Support project
           project-url: https://github.com/orgs/bitnami/projects/4
-          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
       - name: Add to column
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
         if: ${{steps.get-item.outputs.author != 'bitnami-bot' || steps.get-item.outputs.type != 'pull_request'}}
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
-          github_token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
           values: ${{ (contains(fromJson(env.BITNAMI_TEAM), steps.get-item.outputs.author)) && 'From Bitnami' || 'Triage' }}
@@ -73,7 +73,7 @@ jobs:
       - name: Get item info
         id: get-item
         env:
-          GITHUB_TOKEN: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
         run: |
           author="${{ github.event.issue != null && github.event.issue.user.login || github.event.pull_request.user.login }}"
           number="${{ github.event.issue != null && github.event.issue.number || github.event.pull_request.number }}"
@@ -100,7 +100,7 @@ jobs:
         if: ${{ steps.get-item.outputs.type != 'issue' && contains(fromJson(env.BITNAMI_TEAM), steps.get-item.outputs.author) }}
         with:
           # Bitnami bot token is required to trigger CI workflows
-          repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          repo-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           add-labels: verify
       - name: Triage labeling
         uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da

--- a/.github/workflows/pr-review-requested-sync.yml
+++ b/.github/workflows/pr-review-requested-sync.yml
@@ -5,7 +5,7 @@ name: '[Support] Review based card movements'
 on:
   workflow_call:
     secrets:
-      BITNAMI_BOT_TOKEN:
+      BITNAMI_SUPPORT_BOARD_TOKEN:
         required: true
 # Remove all permissions by default
 permissions: {}
@@ -38,14 +38,14 @@ jobs:
         with:
           # Support project
           project-url: https://github.com/orgs/bitnami/projects/4
-          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
       - name: Move into In Progress
         # Move the card only if the actor is not a Bitnami member
         if: ${{ !contains(fromJson(env.BITNAMI_TEAM), github.actor) }}
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
-          github_token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
           values: In progress


### PR DESCRIPTION
Use new organization token, `BITNAMI_SUPPORT_BOARD_TOKEN`, to manage the [Support Board](https://github.com/orgs/bitnami/projects/4)