### PR TITLE
Include content repos without projects

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -15,6 +15,36 @@ bitnami/vulndb:
 bitnami/readme-generator-for-helm:
   - source: workflows/
     dest: .github/workflows/
+bitnami/chart-docs:
+  - source: workflows/
+    dest: .github/workflows/
+bitnami/minideb:
+  - source: workflows/
+    dest: .github/workflows/
+bitnami/chart-categories-action:
+  - source: workflows/
+    dest: .github/workflows/
+bitnami/wait-for-port:
+  - source: workflows/
+    dest: .github/workflows/
+bitnami/render-template:
+  - source: workflows/
+    dest: .github/workflows/
+bitnami/ini-file:
+  - source: workflows/
+    dest: .github/workflows/
+bitnami/gonit:
+  - source: workflows/
+    dest: .github/workflows/
+bitnami/bndiagnostic:
+  - source: workflows/
+    dest: .github/workflows/
+bitnami/bncert:
+  - source: workflows/
+    dest: .github/workflows/
+bitnami/healthcheck-tools:
+  - source: workflows/
+    dest: .github/workflows/
 # Uncoment for migration
 # bitnami/charts:
 #   - source: workflows/


### PR DESCRIPTION
Include following repos in the [Support Dashboard](https://github.com/orgs/bitnami/projects/4):
* https://github.com/bitnami/charts-docs
* https://github.com/bitnami/minideb
* https://github.com/bitnami/chart-categories-action
* https://github.com/bitnami/wait-for-port
* https://github.com/bitnami/render-template
* https://github.com/bitnami/ini-file
* https://github.com/bitnami/gonit
* https://github.com/bitnami/bndiagnostic
* https://github.com/bitnami/bncert
* https://github.com/bitnami/healthcheck-tools