### PR TITLE
Use pull_request_target event instead of pull_request

### DIFF
--- a/workflows/reasign.yml
+++ b/workflows/reasign.yml
@@ -3,7 +3,7 @@
 
 name: '[Support] Review based card movements'
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
   issues:


### PR DESCRIPTION
Events are not triggered correctly in forks. Our workflows requires be triggered with the context of the base of the pull request.