### PR TITLE
Move concurrency rules to the caller workflow

### DIFF
--- a/.github/workflows/comment-created.yml
+++ b/.github/workflows/comment-created.yml
@@ -9,9 +9,6 @@ on:
         required: true
 # Remove all permissions by default
 permissions: {}
-# Avoid concurrency over the same issue
-concurrency:
-  group: card-movement-${{ github.event.repository.id }}-${{ github.event.issue.number }}
 jobs:
   comments_handler:
     runs-on: ubuntu-latest

--- a/.github/workflows/item-closed.yml
+++ b/.github/workflows/item-closed.yml
@@ -9,9 +9,6 @@ on:
         required: true
 # Remove all permissions by default. Actions are performed by Bitnami Bot
 permissions: {}
-# Avoid concurrency over the same issue
-concurrency:
-  group: card-movement-${{ github.event.repository.id }}-${{ github.event.issue != null && github.event.issue.number || github.event.number }}
 jobs:
   send_to_solved:
     runs-on: ubuntu-latest

--- a/.github/workflows/item-labeled.yml
+++ b/.github/workflows/item-labeled.yml
@@ -10,9 +10,6 @@ on:
         required: true
 # Remove all permissions by default
 permissions: {}
-# Avoid concurrency over the same issue
-concurrency:
-  group: card-movement-${{ github.event.repository.id }}-${{ github.event.issue != null && github.event.issue.number || github.event.number }}
 jobs:
   get-info:
     name: Get labels info
@@ -45,7 +42,7 @@ jobs:
           assignees=$(echo "$assignment" | jq -cr ".\"${group}-assignees\" // empty")
           # If there is no assignees and the team is not empty
           if [[ -n "$assignment_team" ]] && [[ -z "$assignees" ]]; then
-            assignees=$(gh api "/orgs/bitnami/teams/${assignment_team}/members" |jq 'sort_by(.login)|map(.login)|join(",")')
+            assignees=$(gh api "/orgs/bitnami/teams/${assignment_team}/members" |jq -cr 'sort_by(.login)|map(.login)|join(",")')
           fi
           label_keys=$(echo "$LABEL_MAPPING"| jq -cr 'keys')
           echo "author=${author}" >> $GITHUB_OUTPUT

--- a/.github/workflows/item-opened.yml
+++ b/.github/workflows/item-opened.yml
@@ -10,9 +10,6 @@ on:
         required: true
 # Remove all permissions by default
 permissions: {}
-# Avoid concurrency over the same issue
-concurrency:
-  group: card-movement-${{ github.event.repository.id }}-${{ github.event.issue != null && github.event.issue.number || github.event.number }}
 jobs:
   # For any opened or reopened issue, should be sent into Triage
   send_to_board:

--- a/.github/workflows/pr-review-requested-sync.yml
+++ b/.github/workflows/pr-review-requested-sync.yml
@@ -9,8 +9,6 @@ on:
         required: true
 # Remove all permissions by default
 permissions: {}
-concurrency:
-  group: card-movement-${{ github.event.repository.id }}-${{ github.event.number }}
 jobs:
   handler:
     permissions:

--- a/workflows/comments.yml
+++ b/workflows/comments.yml
@@ -10,6 +10,9 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+# Avoid concurrency over the same issue
+concurrency:
+  group: card-movement-${{ github.event.issue.number }}
 jobs:
   call-comments-workflow:
     uses: bitnami/support/.github/workflows/comment-created.yml@main

--- a/workflows/move-closed-issues.yml
+++ b/workflows/move-closed-issues.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   issues: write
   pull-requests: write
+# Avoid concurrency over the same issue
+concurrency:
+  group: card-movement-${{ github.event.repository.id }}-${{ github.event.issue != null && github.event.issue.number || github.event.number }}
 jobs:
   call-move-closed-workflow:
     uses: bitnami/support/.github/workflows/item-closed.yml@main

--- a/workflows/pr-reviews.yml
+++ b/workflows/pr-reviews.yml
@@ -9,6 +9,9 @@ on:
       - synchronize
 permissions:
   contents: read
+# Avoid concurrency over the same issue
+concurrency:
+  group: card-movement-${{ github.event.number }}
 jobs:
   call-pr-review-workflow:
     uses: bitnami/support/.github/workflows/pr-review-requested-sync.yml@main

--- a/workflows/reasign.yml
+++ b/workflows/reasign.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+# Avoid concurrency over the same issue
+concurrency:
+  group: card-movement-${{ github.event.issue != null && github.event.issue.number || github.event.number }}
 jobs:
   call-reasign-workflow:
     uses: bitnami/support/.github/workflows/item-labeled.yml@main

--- a/workflows/triage.yml
+++ b/workflows/triage.yml
@@ -16,6 +16,9 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+# Avoid concurrency over the same issue
+concurrency:
+  group: card-movement-${{ github.event.issue != null && github.event.issue.number || github.event.number }}
 jobs:
   call-triage-workflow:
     uses: bitnami/support/.github/workflows/item-opened.yml@main


### PR DESCRIPTION
Concurrency rules are not running as expected in the reusable workflow side. It seem is not accessing to the gihub context during evaluation and I am seeing errors like:
```console
Canceling since a higher priority waiting request for 'card-movement--' exists
```

https://github.com/bitnami/charts-docs/actions/runs/7036270786/attempts/1