### PR TITLE
Fix some issues regarding to labeling and assignment

### DIFF
--- a/.github/workflows/comment-created.yml
+++ b/.github/workflows/comment-created.yml
@@ -85,9 +85,10 @@ jobs:
       - name: Get item info
         id: get-item
         run: |
-          author="${{ github.event.issue != null && github.event.issue.user.login || github.event.pull_request.user.login }}"
-          number="${{ github.event.issue != null && github.event.issue.number || github.event.pull_request.number }}"
-          type="${{ github.event.issue != null && 'issue' || 'pull_request' }}"
+          # Note issue_comment event is slightly than issues or pull_request. More info here: https://docs.github.com/en/webhooks/webhook-events-and-payloads#issue_comment
+          author="${{ github.event.issue.user.login }}"
+          number="${{ github.event.issue.number }}"
+          type="${{ github.event.issue.pull_request != null && 'pull_request' || 'issue' }}"
           echo "author=${author}" >> $GITHUB_OUTPUT
           echo "number=${number}" >> $GITHUB_OUTPUT
           echo "type=${type}" >> $GITHUB_OUTPUT

--- a/.github/workflows/comment-created.yml
+++ b/.github/workflows/comment-created.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Get item info
         id: get-item
         run: |
-          # Note issue_comment event is slightly than issues or pull_request. More info here: https://docs.github.com/en/webhooks/webhook-events-and-payloads#issue_comment
+          # Note issue_comment event is slightly different than issues or pull_request. More info here: https://docs.github.com/en/webhooks/webhook-events-and-payloads#issue_comment
           author="${{ github.event.issue.user.login }}"
           number="${{ github.event.issue.number }}"
           type="${{ github.event.issue.pull_request != null && 'pull_request' || 'issue' }}"

--- a/.github/workflows/item-labeled.yml
+++ b/.github/workflows/item-labeled.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Assign issue/PR
         uses: pozil/auto-assign-issue@edee9537367a8fbc625d27f9e10aa8bad47b8723
         with:
+          numOfAssignee: 1
           removePreviousAssignees: ${{ github.event.label.name == 'in-progress' }}
           assignees: ${{ needs.get-info.outputs.assignees }}
           # If we have repos with only one assignees we allow selfAssignment


### PR DESCRIPTION
Several fixes:
* Amend label assignment for Build Maintenance tasks.
* Set number of assignees to 1 when tasks are moved.