### PR TITLE
Move cards based on PR reviews

### DIFF
--- a/.github/workflows/pr-review-comment.yml
+++ b/.github/workflows/pr-review-comment.yml
@@ -16,6 +16,13 @@ jobs:
       github.event.pull_request.user.login != 'bitnami-bot' &&
       (!contains(github.event.pull_request.labels.*.name, 'bitnami'))
     steps:
+      - name: Repo checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: 1
+          repository: bitnami/support
+      - name: Load .env file
+        uses: xom9ikk/dotenv@de1ff27d319507880e6621e4d47424c677d95f68
       - name: Add to board
         id: add-to-project
         uses: actions/add-to-project@0be3b6580ae2145e72e0ada85d693ab71a5f17d6
@@ -30,4 +37,4 @@ jobs:
           github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
-          values: Pending
+          values: ${{ contains(fromJson(env.BITNAMI_TEAM), github.event.comment.user.login) && 'Pending' || 'In Progress' }}

--- a/.github/workflows/pr-review-comment.yml
+++ b/.github/workflows/pr-review-comment.yml
@@ -1,0 +1,33 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
+name: '[Support] PR review comment card movement'
+on:
+  workflow_call:
+    secrets:
+      BITNAMI_SUPPORT_BOARD_TOKEN:
+        required: true
+# Remove all permissions by default
+permissions: {}
+jobs:
+  comments_handler:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.user.login != 'bitnami-bot' &&
+      (!contains(github.event.pull_request.labels.*.name, 'bitnami'))
+    steps:
+      - name: Add to board
+        id: add-to-project
+        uses: actions/add-to-project@0be3b6580ae2145e72e0ada85d693ab71a5f17d6
+        with:
+          # Support project
+          project-url: https://github.com/orgs/bitnami/projects/4
+          github-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
+      - name: Move into Pending
+        uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
+        with:
+          project_url: https://github.com/orgs/bitnami/projects/4
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
+          operation: set
+          fields: Status
+          values: Pending

--- a/.github/workflows/pr-review-comment.yml
+++ b/.github/workflows/pr-review-comment.yml
@@ -30,11 +30,21 @@ jobs:
           # Support project
           project-url: https://github.com/orgs/bitnami/projects/4
           github-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
-      - name: Move card
+      - name: Move into Pending 
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
+        if: ${{ contains(fromJson(env.BITNAMI_TEAM), github.event.comment.user.login) }}
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
           github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
-          values: ${{ contains(fromJson(env.BITNAMI_TEAM), github.event.comment.user.login) && 'Pending' || 'In Progress' }}
+          values: Pending
+      - name: Move into Triage/In Progress 
+        uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
+        if: ${{ ! contains(fromJson(env.BITNAMI_TEAM), github.event.comment.user.login) }}
+        with:
+          project_url: https://github.com/orgs/bitnami/projects/4
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
+          operation: set
+          fields: Status
+          values: ${{ contains(github.event.pull_request.labels.*.name, 'in-progress') && 'In Progress' || 'Triage' }}

--- a/.github/workflows/pr-review-comment.yml
+++ b/.github/workflows/pr-review-comment.yml
@@ -23,7 +23,7 @@ jobs:
           # Support project
           project-url: https://github.com/orgs/bitnami/projects/4
           github-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
-      - name: Move into Pending
+      - name: Move card
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
         with:
           project_url: https://github.com/orgs/bitnami/projects/4

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,43 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
+name: '[Support] PR review card movement'
+on:
+  workflow_call:
+    secrets:
+      BITNAMI_SUPPORT_BOARD_TOKEN:
+        required: true
+# Remove all permissions by default
+permissions: {}
+jobs:
+  comments_handler:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.user.login != 'bitnami-bot' &&
+      (!contains(github.event.pull_request.labels.*.name, 'bitnami'))
+    steps:
+      - name: Add to board
+        id: add-to-project
+        uses: actions/add-to-project@0be3b6580ae2145e72e0ada85d693ab71a5f17d6
+        with:
+          # Support project
+          project-url: https://github.com/orgs/bitnami/projects/4
+          github-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
+      - name: Move into Pending
+        uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
+        if: ${{ github.event.review.state == 'changes_requested' }}
+        with:
+          project_url: https://github.com/orgs/bitnami/projects/4
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
+          operation: set
+          fields: Status
+          values: Pending
+      - name: Move into In Progress/Triage
+        uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
+        if: ${{ github.event.review.state == 'dismissed' }}
+        with:
+          project_url: https://github.com/orgs/bitnami/projects/4
+          github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
+          operation: set
+          fields: Status
+          values: ${{ contains(github.event.pull_request.labels.*.name, 'in-progress') && 'In Progress' || 'Triage' }}

--- a/workflows/pr-reviews-requested.yml
+++ b/workflows/pr-reviews-requested.yml
@@ -1,0 +1,18 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
+name: '[Support] Review based card movements'
+on:
+  pull_request_target:
+    types:
+      - review_requested
+      - synchronize
+permissions:
+  contents: read
+# Avoid concurrency over the same issue
+concurrency:
+  group: card-movement-${{ github.event.number }}
+jobs:
+  call-pr-review-workflow:
+    uses: bitnami/support/.github/workflows/pr-review-requested-sync.yml@main
+    secrets: inherit

--- a/workflows/pr-reviews.yml
+++ b/workflows/pr-reviews.yml
@@ -1,18 +1,25 @@
 # Copyright VMware, Inc.
 # SPDX-License-Identifier: APACHE-2.0
 
-name: '[Support] Review based card movements'
+name: '[Support] PR review comment card movements'
 on:
-  pull_request_target:
+  pull_request_review_comment:
     types:
-      - review_requested
-      - synchronize
-permissions:
-  contents: read
+      - created
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
+permissions: {}
 # Avoid concurrency over the same issue
 concurrency:
-  group: card-movement-${{ github.event.number }}
+  group: card-movement-${{ github.event.pull_request.number }}
 jobs:
+  call-pr-review-comment-workflow:
+    if: ${{ github.event_name == 'pull_request_review_comment' }}
+    uses: bitnami/support/.github/workflows/pr-review-comment.yml@main
+    secrets: inherit
   call-pr-review-workflow:
-    uses: bitnami/support/.github/workflows/pr-review-requested-sync.yml@main
+    if: ${{ github.event_name == 'pull_request_review' }}
+    uses: bitnami/support/.github/workflows/pr-review.yml@main
     secrets: inherit


### PR DESCRIPTION
PR reviews (comments, changes requested or review dimissed) were not managed by existing workflows and the cards were not moved properly.

With these changes our workflows will be listening for `pull_request_review_comment` and `pull_request_review` events we will be able to move the cards to the right column.

NOTE: PRs created by bitnami-bot or created by bitnami team are ignored.