### PR TITLE
Move cards based on PR reviews (forked repos)

### DIFF
--- a/.github/workflows/pr-review-comment.yml
+++ b/.github/workflows/pr-review-comment.yml
@@ -39,18 +39,12 @@ jobs:
           repository: bitnami/support
       - name: Load .env file
         uses: xom9ikk/dotenv@de1ff27d319507880e6621e4d47424c677d95f68
-      - name: Add to board
-        id: add-to-project
-        uses: actions/add-to-project@0be3b6580ae2145e72e0ada85d693ab71a5f17d6
-        with:
-          # Support project
-          project-url: https://github.com/orgs/bitnami/projects/4
-          github-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
       - name: Move into Pending 
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
         if: ${{ contains(fromJson(env.BITNAMI_TEAM), inputs.actor) }}
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
+          resource_url: ${{ inputs.resource_url }}
           github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
@@ -60,6 +54,7 @@ jobs:
         if: ${{ !contains(fromJson(env.BITNAMI_TEAM), inputs.actor) }}
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
+          resource_url: ${{ inputs.resource_url }}
           github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status

--- a/.github/workflows/pr-review-comment.yml
+++ b/.github/workflows/pr-review-comment.yml
@@ -4,6 +4,22 @@
 name: '[Support] PR review comment card movement'
 on:
   workflow_call:
+    inputs:
+      author:
+        required: true
+        type: string
+      actor:
+        required: true
+        type: string
+      resource_url:
+        required: true
+        type: string
+      labels:
+        required: true
+        type: string
+      author_association:
+        required: false
+        type: string
     secrets:
       BITNAMI_SUPPORT_BOARD_TOKEN:
         required: true
@@ -13,8 +29,8 @@ jobs:
   comments_handler:
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.user.login != 'bitnami-bot' &&
-      (!contains(github.event.pull_request.labels.*.name, 'bitnami'))
+      inputs.author != 'bitnami-bot' &&
+      (!contains(fromJson(inputs.labels).*.name, 'bitnami'))
     steps:
       - name: Repo checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -32,7 +48,7 @@ jobs:
           github-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
       - name: Move into Pending 
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
-        if: ${{ contains(fromJson(env.BITNAMI_TEAM), github.event.comment.user.login) }}
+        if: ${{ contains(fromJson(env.BITNAMI_TEAM), inputs.actor) }}
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
           github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
@@ -41,10 +57,10 @@ jobs:
           values: Pending
       - name: Move into Triage/In Progress 
         uses: EndBug/project-fields@47306ad805cdba6fc5bb9e698b9d0c81c366c629
-        if: ${{ ! contains(fromJson(env.BITNAMI_TEAM), github.event.comment.user.login) }}
+        if: ${{ !contains(fromJson(env.BITNAMI_TEAM), inputs.actor) }}
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
           github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
           operation: set
           fields: Status
-          values: ${{ contains(github.event.pull_request.labels.*.name, 'in-progress') && 'In Progress' || 'Triage' }}
+          values: ${{ contains(fromJson(inputs.labels).*.name, 'in-progress') && 'In Progress' || 'Triage' }}

--- a/workflows/pr-review-hack.yml
+++ b/workflows/pr-review-hack.yml
@@ -1,0 +1,51 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
+# This is a hack to run reusable workflows in the main repo context and not from the forked repository.
+# We this hack we can use secrets configured in the organization.
+name: '[Support] PR review comment trigger'
+on:
+  workflow_run:
+    workflows:
+      - '\[Support\] PR review comment card movements'
+    types:
+      - completed
+permissions: {}
+jobs:
+  pr-info:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      author: ${{ steps.get-info.outputs.author }}
+      actor: ${{ steps.get-info.outputs.actor }}
+      labels: ${{ steps.get-info.outputs.labels }}
+      resource_url: ${{ steps.get-info.outputs.resource_url }}
+    steps:
+      - id: get-info
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          actor="${{ github.event.workflow_run.actor.login }}"
+          pull_request="$(gh api "${{ github.event.workflow_run.pull_requests[0].url }}")"
+          author="$(echo $pull_request | jq -cr '.user.login')"
+          author_association="$(echo $pull_request | jq -cr '.author_association')"
+          labels="$(echo $pull_request | jq -cr '[.labels[].name]')"
+          resource_url="$(echo $pull_request | jq -cr '.html_url')"
+
+          echo "actor=${actor}" >> $GITHUB_OUTPUT
+          echo "author=${author}" >> $GITHUB_OUTPUT
+          echo "author_association=${author_association}" >> $GITHUB_OUTPUT
+          echo "labels=${labels}" >> $GITHUB_OUTPUT
+          echo "resource_url=${resource_url}" >> $GITHUB_OUTPUT
+  call-pr-review-comment:
+    uses: bitnami/support/.github/workflows/pr-review-comment.yml@main
+    needs: pr-info
+    permissions:
+      contents: read
+    secrets: inherit
+    with:
+      author: ${{ needs.pr-info.outputs.author }}
+      actor: ${{ needs.pr-info.outputs.actor }}
+      labels: ${{ needs.pr-info.outputs.labels }}
+      resource_url: ${{ needs.pr-info.outputs.resource_url }}

--- a/workflows/pr-reviews.yml
+++ b/workflows/pr-reviews.yml
@@ -6,20 +6,15 @@ on:
   pull_request_review_comment:
     types:
       - created
-  pull_request_review:
-    types:
-      - submitted
-      - dismissed
 permissions: {}
 # Avoid concurrency over the same issue
 concurrency:
   group: card-movement-${{ github.event.pull_request.number }}
 jobs:
-  call-pr-review-comment-workflow:
-    if: ${{ github.event_name == 'pull_request_review_comment' }}
-    uses: bitnami/support/.github/workflows/pr-review-comment.yml@main
-    secrets: inherit
-  call-pr-review-workflow:
-    if: ${{ github.event_name == 'pull_request_review' }}
-    uses: bitnami/support/.github/workflows/pr-review.yml@main
-    secrets: inherit
+  just-notice:
+    # This is a dummy workflow that triggers a workflow_run
+    runs-on: ubuntu-latest
+    steps:
+      - id: 
+        run: |
+          echo "::notice:: Comment on PR #${{ github.event.pull_request.number }}"


### PR DESCRIPTION
This is a #22 follow up.

These changes are needed because we can not move the cards on `pull_request_review_comment` events in forked repositories because we cannot access secrets in that scenario. To achieve this goal we need a little hack, the `pull_request_review_comment` will trigger a little workflow with a notice and a new workflow with the necessary code to move the cards, will be triggered once previous workflow finishes (on `workflow_run`).

NOTE: To simplify we are not adding the card to the project board, the card should have been created previously.