### PR TITLE
Move cards based on PR reviews (forked repos)

### DIFF
--- a/workflows/pr-review-hack.yml
+++ b/workflows/pr-review-hack.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
+      actions: read
     outputs:
       author: ${{ steps.get-info.outputs.author }}
       actor: ${{ steps.get-info.outputs.actor }}
@@ -27,12 +28,17 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           actor="${{ github.event.workflow_run.actor.login }}"
-          pull_request="$(gh api "${{ github.event.workflow_run.pull_requests[0].url }}")"
+          download_url="$(gh api "${{ github.event.workflow_run.artifacts_url }}" | jq -cr '.artifacts[] | select(.name == "pull_request_number") | .archive_download_url')"
+          curl -sSL -o pull_request_number.zip -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer $GITHUB_TOKEN" $download_url
+          unzip pull_request_number.zip
+          pull_request_number=$(cat pull_request_number)
+          pull_request="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pull_request_number}")"
           author="$(echo $pull_request | jq -cr '.user.login')"
           author_association="$(echo $pull_request | jq -cr '.author_association')"
           labels="$(echo $pull_request | jq -cr '[.labels[].name]')"
           resource_url="$(echo $pull_request | jq -cr '.html_url')"
 
+          echo "::notice:: Managing PR #${pull_request_number}"
           echo "actor=${actor}" >> $GITHUB_OUTPUT
           echo "author=${author}" >> $GITHUB_OUTPUT
           echo "author_association=${author_association}" >> $GITHUB_OUTPUT

--- a/workflows/pr-reviews.yml
+++ b/workflows/pr-reviews.yml
@@ -17,3 +17,9 @@ jobs:
     steps:
       - run: |
           echo "::notice:: Comment on PR #${{ github.event.pull_request.number }}"
+          echo "${{ github.event.pull_request.number }}" > pull_request_number
+      - name: Upload the PR number
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        with:
+          name: pull_request_number
+          path: ./pull_request_number


### PR DESCRIPTION
This is a https://github.com/bitnami/support/pull/22 follow up.

`workflow_run` event doesn't include `pull_requests` when the event comes from a forked repository. With these changes we will use an artifact to pass the PR number between workflows.