### PR TITLE
Improve dependabot integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,20 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    reviewers:
+      - fmulero
+      - carrodher
+    assignees:
+      - fmulero
+      - carrodher
+  - package-ecosystem: "github-actions"
+    directory: "/workflows"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - fmulero
+      - carrodher
+    assignees:
+      - fmulero
+      - carrodher


### PR DESCRIPTION
Changes merged in #41 didn't work as expected due to [this](https://github.com/dependabot/dependabot-core/issues/4899#issuecomment-1416029666). Those changes were reverted (#43) and this PR tries to run github-actions dependabot in the `/workflows` folder