### PR TITLE
Move cards on Review submission

### DIFF
--- a/workflows/pr-reviews.yml
+++ b/workflows/pr-reviews.yml
@@ -6,6 +6,10 @@ on:
   pull_request_review_comment:
     types:
       - created
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
 permissions: {}
 # Avoid concurrency over the same issue
 concurrency:


### PR DESCRIPTION

## Description of the change

Change `PR review comment card movements` workflow to listen on `pull_request_review` events.

##  Benefits

Move cards when changes are requested or the user commits changes and our review is dismissed.