### PR TITLE
Avoid moving approved PRs to Pending column

### DIFF
--- a/.github/workflows/pr-review-comment.yml
+++ b/.github/workflows/pr-review-comment.yml
@@ -17,6 +17,9 @@ on:
       labels:
         required: true
         type: string
+      review_state:
+        required: true
+        type: string
       author_association:
         required: false
         type: string
@@ -41,7 +44,9 @@ jobs:
         uses: xom9ikk/dotenv@ac290ca23a42155a0cba1031d23afa46240116a9
       - name: Move into Pending 
         uses: EndBug/project-fields@52c2f411fd7e8982ef41656212d0f6db8de5468b
-        if: ${{ contains(fromJson(env.BITNAMI_TEAM), inputs.actor) }}
+        if: |
+          contains(fromJson(env.BITNAMI_TEAM), inputs.actor) &&
+          inputs.review_state != 'APPROVED'
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
           resource_url: ${{ inputs.resource_url }}

--- a/workflows/pr-review-hack.yml
+++ b/workflows/pr-review-hack.yml
@@ -29,10 +29,11 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           actor="${{ github.event.workflow_run.actor.login }}"
-          download_url="$(gh api "${{ github.event.workflow_run.artifacts_url }}" | jq -cr '.artifacts[] | select(.name == "pull_request_number") | .archive_download_url')"
-          curl -sSL -o pull_request_number.zip -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer $GITHUB_TOKEN" $download_url
-          unzip pull_request_number.zip
-          pull_request_number=$(cat pull_request_number)
+          download_url="$(gh api "${{ github.event.workflow_run.artifacts_url }}" | jq -cr '.artifacts[] | select(.name == "pull_request_info.json") | .archive_download_url')"
+          curl -sSL -o pull_request_info.zip -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "Authorization: Bearer $GITHUB_TOKEN" $download_url
+          unzip pull_request_info.zip
+          pull_request_number=$(jq '.issue.number' pull_request_info.json)
+          issue_review_state="$(jq '.review.state' pull_request_info.json)"
           pull_request="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pull_request_number}")"
           author="$(echo $pull_request | jq -cr '.user.login')"
           author_association="$(echo $pull_request | jq -cr '.author_association')"
@@ -43,6 +44,7 @@ jobs:
           echo "actor=${actor}" >> $GITHUB_OUTPUT
           echo "author=${author}" >> $GITHUB_OUTPUT
           echo "author_association=${author_association}" >> $GITHUB_OUTPUT
+          echo "review_state=${issue_review_state}"
           echo "labels=${labels}" >> $GITHUB_OUTPUT
           echo "resource_url=${resource_url}" >> $GITHUB_OUTPUT
   call-pr-review-comment:
@@ -55,4 +57,5 @@ jobs:
       author: ${{ needs.pr-info.outputs.author }}
       actor: ${{ needs.pr-info.outputs.actor }}
       labels: ${{ needs.pr-info.outputs.labels }}
+      review_state: ${{ needs.pr-info.outputs.review_state }}
       resource_url: ${{ needs.pr-info.outputs.resource_url }}

--- a/workflows/pr-reviews.yml
+++ b/workflows/pr-reviews.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
       - run: |
           echo "::notice:: Comment on PR #${{ github.event.pull_request.number }}"
-          echo "${{ github.event.pull_request.number }}" > pull_request_number
-      - name: Upload the PR number
+          jq -n --arg issue '${{ github.event.pull_request.number }}' --arg state '${{ github.event.review != null && github.event.review.state || '' }}' '{"issue": {"number": $issue }, "review": { "state": $state }}' > pull_request_info.json
+      - name: Upload the PR info
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
-          name: pull_request_number
-          path: ./pull_request_number
+          name: pull_request_info.json
+          path: ./pull_request_info.json


### PR DESCRIPTION
This PR tries to fix a recent issue detected on approved PRs what are in the Pending column instead of the "Solved" one.

The problem was happening because in some cases the `pr-review-comment.yml` workflow was moving the PR after it was merged/closed. A regular use case from bitnami side is:
* A PRs is reviewed.
* If everything goes well the PR is approved. (this triggers workflows associated to PR review)
* If Protection rules are OK the PR is immediately merged. (this triggers workflows associate to the PR close)

With these changes, the PR won't be moved if it is approved by a Bitnami member.