### PR TITLE
Do not add 'verify' label when PR is created by bitnami-bot

### DIFF
--- a/.github/workflows/item-opened.yml
+++ b/.github/workflows/item-opened.yml
@@ -95,10 +95,7 @@ jobs:
           add-labels: 'automated, auto-merge'
       - name: Verify labeling
         uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
-        if: |
-          steps.get-item.outputs.type != 'issue' &&
-          steps.get-item.outputs.author != 'bitnami-bot' &&
-          contains(fromJson(env.BITNAMI_TEAM), steps.get-item.outputs.author) &&
+        if: ${{ steps.get-item.outputs.type != 'issue' && contains(fromJson(env.BITNAMI_TEAM), steps.get-item.outputs.author) }}
         with:
           # In the past, we added the repo-token to ensure adding this label triggered a workflow
           # It is no longer needed since the changelog PR will automatically trigger a new workflow

--- a/.github/workflows/item-opened.yml
+++ b/.github/workflows/item-opened.yml
@@ -100,8 +100,8 @@ jobs:
           steps.get-item.outputs.author != 'bitnami-bot' &&
           contains(fromJson(env.BITNAMI_TEAM), steps.get-item.outputs.author) &&
         with:
-          # Bitnami bot token is required to trigger CI workflows
-          repo-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
+          # In the past, we added the repo-token to ensure adding this label triggered a workflow
+          # It is no longer needed since the changelog PR will automatically trigger a new workflow
           add-labels: verify
       - name: Triage labeling
         uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da

--- a/.github/workflows/item-opened.yml
+++ b/.github/workflows/item-opened.yml
@@ -95,7 +95,10 @@ jobs:
           add-labels: 'automated, auto-merge'
       - name: Verify labeling
         uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
-        if: ${{ steps.get-item.outputs.type != 'issue' && contains(fromJson(env.BITNAMI_TEAM), steps.get-item.outputs.author) }}
+        if: |
+          steps.get-item.outputs.type != 'issue' &&
+          steps.get-item.outputs.author != 'bitnami-bot' &&
+          contains(fromJson(env.BITNAMI_TEAM), steps.get-item.outputs.author) &&
         with:
           # Bitnami bot token is required to trigger CI workflows
           repo-token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}
@@ -108,7 +111,7 @@ jobs:
         with:
           add-labels: ${{ (contains(fromJson(env.BITNAMI_TEAM), steps.get-item.outputs.author)) && 'bitnami' || 'triage' }}
           remove-labels: on-hold, in-progress, solved, ${{ (contains(fromJson(env.BITNAMI_TEAM), steps.get-item.outputs.author)) && 'triage' || 'bitnami' }}
-      - name: 
+      - name: Assign issue
         uses: pozil/auto-assign-issue@c5bca5027e680b9e8411b826d16947afd8c76b32
         if: ${{ steps.get-item.outputs.author != 'bitnami-bot' }}
         with:


### PR DESCRIPTION
### Description of the change

Do not force 'verify' label to trigger a new workflow

### Benefits

Fixes current issues with automatic PRs:

* The issues are not been moved to the Done column in the support board.
* An Error message is displayed after the PR is successfully approved and merged.

### Additional information

The current approach will always starts 3 CI/CD pipeline workflows when a PR is created by a bitnami member, including 'bitnami-bot'.

It is important to know how workflows concurrency works, see [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs) for more info:
> When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any pending job or workflow in the concurrency group will be canceled. This means that there can be at most one running and one pending job in a concurrency group at any time.

Due to the latest additions to the CI pipeline, the 'update-pr' is **always** executed (due to the changelog update).

This results in these three workflows, in the following order:
- 1st workflow: Initial commit / PR created.
- 2nd workflow: verify label added.
- 3rd workflow: 'Update changelog commit' (triggered by 1st workflow).

What's the problem? Usually, the 2nd workflow will be superseded by the 3rd, since its status would be pending when the 3rd workflow is sent and it will be skipped.

Sometimes, the 2nd workflow is not superseded, and both the 3rd and 2nd workflow are executed.

This causes the 2nd workflow to merge the PR, and the 3rd workflow results in the error message and wrong support card movement.

Affected (https://github.com/bitnami/charts/pull/29539):
![image](https://github.com/user-attachments/assets/9e65f72e-71bf-4cbf-a317-d7fb62e6eddc)

Not affected(https://github.com/bitnami/charts/pull/29549): 
![image](https://github.com/user-attachments/assets/f96fcf74-a0ff-499a-bc60-bacca2583d70)

### How does this approach fix this issue?

This issue ensures that the second workflow never happens by not including the token.

### Possible drawbacks

If a PR from Bitnami already includes the Changelog changes (the 'update-pr'  is no executed), the VIB verify step won't be automatically triggered, which will require manual trigger.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
