### PR TITLE
Skip repo-token only for bitnami/charts repository

### DIFF
--- a/.github/workflows/item-opened.yml
+++ b/.github/workflows/item-opened.yml
@@ -98,8 +98,8 @@ jobs:
         if: ${{ steps.get-item.outputs.type != 'issue' && contains(fromJson(env.BITNAMI_TEAM), steps.get-item.outputs.author) }}
         with:
           # Bitnami bot token is required to trigger CI workflows
-          # Not needed for bitnami/charts repo since the changelog PR will automatically trigger a new workflow
-          repo-token: ${{ github.event.repository.name == 'bitnami/charts' && github.token || secrets.BITNAMI_SUPPORT_BOARD_TOKEN}}
+          # Not needed for charts repo since the changelog PR will automatically trigger a new workflow
+          repo-token: ${{ github.event.repository.name == 'charts' && github.token || secrets.BITNAMI_SUPPORT_BOARD_TOKEN}}
           add-labels: verify
       - name: Triage labeling
         uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da

--- a/.github/workflows/item-opened.yml
+++ b/.github/workflows/item-opened.yml
@@ -97,8 +97,9 @@ jobs:
         uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da
         if: ${{ steps.get-item.outputs.type != 'issue' && contains(fromJson(env.BITNAMI_TEAM), steps.get-item.outputs.author) }}
         with:
-          # In the past, we added the repo-token to ensure adding this label triggered a workflow
-          # It is no longer needed since the changelog PR will automatically trigger a new workflow
+          # Bitnami bot token is required to trigger CI workflows
+          # Not needed for bitnami/charts repo since the changelog PR will automatically trigger a new workflow
+          repo-token: ${{ github.event.repository.name == 'bitnami/charts' && github.token || secrets.BITNAMI_SUPPORT_BOARD_TOKEN}}
           add-labels: verify
       - name: Triage labeling
         uses: fmulero/labeler@f49bf680252fc8ac12cbebb6e0ed8ea19d0712da


### PR DESCRIPTION
Partially reverts https://github.com/bitnami/support/pull/77

Skip repo-token only for `bitnami/charts`, since it is the only repository that may not require forcing a workflow trigger.

When the repository.name is 'bitnami/charts', it will use the default job token. See [github docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#about-the-github_token-secret) and [labeler action default](https://github.com/fmulero/labeler/blob/main/action.yml#L4-L7)