### PR TITLE
Fix condition on bitnami-bot send-solved PRs

### DIFF
--- a/.github/workflows/item-closed.yml
+++ b/.github/workflows/item-closed.yml
@@ -50,7 +50,7 @@ jobs:
         # Send to solve only the issues and PRs created by users or the automated PRs with human review required
         if: |
           steps.get-item.outputs.author != 'bitnami-bot' ||
-          (steps.get-item.outputs.author == 'bitnami-bot' && !contains(github.event.pull_request.labels.*.name, 'auto-merge'))
+          (steps.get-item.outputs.author == 'bitnami-bot' && (!contains(github.event.pull_request.labels.*.name, 'auto-merge')))
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
           github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}

--- a/.github/workflows/item-closed.yml
+++ b/.github/workflows/item-closed.yml
@@ -50,7 +50,7 @@ jobs:
         # Send to solve only the issues and PRs created by users or the automated PRs with human review required
         if: |
           steps.get-item.outputs.author != 'bitnami-bot' ||
-          (steps.get-item.outputs.author == 'bitnami-bot' && contains(github.event.pull_request.labels.*.name, 'review-required'))
+          (steps.get-item.outputs.author == 'bitnami-bot' && !contains(github.event.pull_request.labels.*.name, 'auto-merge'))
         with:
           project_url: https://github.com/orgs/bitnami/projects/4
           github_token: ${{ secrets.BITNAMI_SUPPORT_BOARD_TOKEN }}


### PR DESCRIPTION
### Description

Fixes an issue with automated PRs that require review not being moved to the Solved column once merged.

The condition required the 'review-required' label to be present on the PR, but the team is removing it during the PR triage.