### PR TITLE
chore(workflows): Add a common stale workflow

### DIFF
--- a/workflows/comments.yml
+++ b/workflows/comments.yml
@@ -1,6 +1,7 @@
 # Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
+# NOTE: This workflow is maintained in the https://github.com/bitnami/support repository
 name: '[Support] Comments based card movements'
 on:
   issue_comment:

--- a/workflows/move-closed-issues.yml
+++ b/workflows/move-closed-issues.yml
@@ -1,6 +1,7 @@
 # Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
+# NOTE: This workflow is maintained in the https://github.com/bitnami/support repository
 name: '[Support] Move closed issues'
 on:
   issues:

--- a/workflows/pr-review-hack.yml
+++ b/workflows/pr-review-hack.yml
@@ -3,6 +3,7 @@
 
 # This is a hack to run reusable workflows in the main repo context and not from the forked repository.
 # We this hack we can use secrets configured in the organization.
+# NOTE: This workflow is maintained in the https://github.com/bitnami/support repository
 name: '[Support] PR review comment trigger'
 on:
   workflow_run:

--- a/workflows/pr-reviews-requested.yml
+++ b/workflows/pr-reviews-requested.yml
@@ -1,6 +1,7 @@
 # Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
+# NOTE: This workflow is maintained in the https://github.com/bitnami/support repository
 name: '[Support] Review based card movements'
 on:
   pull_request_target:

--- a/workflows/pr-reviews.yml
+++ b/workflows/pr-reviews.yml
@@ -1,6 +1,7 @@
 # Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
+# NOTE: This workflow is maintained in the https://github.com/bitnami/support repository
 name: '[Support] PR review comment card movements'
 on:
   pull_request_review_comment:

--- a/workflows/reasign.yml
+++ b/workflows/reasign.yml
@@ -1,6 +1,7 @@
 # Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
+# NOTE: This workflow is maintained in the https://github.com/bitnami/support repository
 name: '[Support] Review based card movements'
 on:
   pull_request_target:

--- a/workflows/stale.yml
+++ b/workflows/stale.yml
@@ -1,0 +1,44 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+# NOTE: This workflow is maintained in the https://github.com/bitnami/support repository
+name: '[Support] Close stale issues and PRs'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
+# Remove all permissions by default
+permissions: {}
+# This job won't trigger any additional event. All actions are performed with GITHUB_TOKEN
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      # This step will add the stale comment and label for the first 15 days without activity. It won't close any task
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.'
+          stale-pr-message: 'This Pull Request has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thank you for your contribution.'
+          days-before-stale: 15
+          days-before-close: -1
+          exempt-issue-labels: 'on-hold'
+          exempt-pr-labels: 'on-hold'
+          operations-per-run: 500
+      # This step will add the 'solved' label and the last comment before closing the issue or PR. Note that it won't close any issue or PR, they will be closed by the clossing-issues workflow
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Issue. Do not hesitate to reopen it later if necessary.'
+          stale-pr-message: 'Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Pull Request. Do not hesitate to reopen it later if necessary.'
+          any-of-labels: 'stale'
+          stale-issue-label: 'solved'
+          stale-pr-label: 'solved'
+          days-before-stale: 5
+          days-before-close: -1
+          exempt-issue-labels: 'on-hold'
+          exempt-pr-labels: 'on-hold'
+          operations-per-run: 200

--- a/workflows/triage.yml
+++ b/workflows/triage.yml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 # This workflow is built to manage the triage support by using GH issues.
+# NOTE: This workflow is maintained in the https://github.com/bitnami/support repository
 name: '[Support] Organize triage'
 on:
   issues:


### PR DESCRIPTION
### Description

Add a common stale workflow (the code was taken from bitnami/containers and bitnami/charts). This change will affect to the following repositories:
* bitnami/vms
* bitnami/vulndb
* bitnami/readme-generator-for-helm
* bitnami/minideb
* bitnami/chart-categories-action
* bitnami/wait-for-port
* bitnami/render-template
* bitnami/ini-file
* bitnami/gonit
* bitnami/bndiagnostic
* bitnami/bncert
* bitnami/healthcheck-tools
* bitnami/charts
* bitnami/containers

Also, a note was added to all the workflows maintained directly from this repository.

