### PR TITLE
chore(workflows): Run support workflows only in bitnami repos

### DIFF
--- a/workflows/clossing-issues.yml
+++ b/workflows/clossing-issues.yml
@@ -12,6 +12,7 @@ permissions: {}
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'bitnami' }}
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
         with:

--- a/workflows/comments.yml
+++ b/workflows/comments.yml
@@ -16,5 +16,6 @@ concurrency:
   group: card-movement-${{ github.event.issue.number }}
 jobs:
   call-comments-workflow:
+    if: ${{ github.repository_owner == 'bitnami' }}
     uses: bitnami/support/.github/workflows/comment-created.yml@main
     secrets: inherit

--- a/workflows/move-closed-issues.yml
+++ b/workflows/move-closed-issues.yml
@@ -18,5 +18,6 @@ concurrency:
   group: card-movement-${{ github.event.issue != null && github.event.issue.number || github.event.number }}
 jobs:
   call-move-closed-workflow:
+    if: ${{ github.repository_owner == 'bitnami' }}
     uses: bitnami/support/.github/workflows/item-closed.yml@main
     secrets: inherit

--- a/workflows/pr-review-hack.yml
+++ b/workflows/pr-review-hack.yml
@@ -24,7 +24,7 @@ jobs:
       review_state: ${{ steps.get-info.outputs.review_state }}
       labels: ${{ steps.get-info.outputs.labels }}
       resource_url: ${{ steps.get-info.outputs.resource_url }}
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository_owner == 'bitnami' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - id: get-info
         env:

--- a/workflows/pr-reviews-requested.yml
+++ b/workflows/pr-reviews-requested.yml
@@ -15,5 +15,6 @@ concurrency:
   group: card-movement-${{ github.event.number }}
 jobs:
   call-pr-review-workflow:
+    if: ${{ github.repository_owner == 'bitnami' }}
     uses: bitnami/support/.github/workflows/pr-review-requested-sync.yml@main
     secrets: inherit

--- a/workflows/pr-reviews.yml
+++ b/workflows/pr-reviews.yml
@@ -19,6 +19,7 @@ jobs:
   just-notice:
     # This is a dummy workflow that triggers a workflow_run
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'bitnami' }}
     steps:
       - run: |
           echo "::notice:: Comment on PR #${{ github.event.pull_request.number }}"

--- a/workflows/reasign.yml
+++ b/workflows/reasign.yml
@@ -19,5 +19,6 @@ concurrency:
   group: card-movement-${{ github.event.issue != null && github.event.issue.number || github.event.number }}
 jobs:
   call-reasign-workflow:
+    if: ${{ github.repository_owner == 'bitnami' }}
     uses: bitnami/support/.github/workflows/item-labeled.yml@main
     secrets: inherit

--- a/workflows/stale.yml
+++ b/workflows/stale.yml
@@ -13,6 +13,7 @@ permissions: {}
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'bitnami' }}
     permissions:
       issues: write
       pull-requests: write

--- a/workflows/triage.yml
+++ b/workflows/triage.yml
@@ -22,5 +22,6 @@ concurrency:
   group: card-movement-${{ github.event.issue != null && github.event.issue.number || github.event.number }}
 jobs:
   call-triage-workflow:
+    if: ${{ github.repository_owner == 'bitnami' }}
     uses: bitnami/support/.github/workflows/item-opened.yml@main
     secrets: inherit


### PR DESCRIPTION
### Description

Run support workflows only in bitnami repos. This will exclude forked repositories.

Related to: https://vmw-jira.broadcom.net/browse/TAC-2626
