### PR TITLE
[TNZ-84434] use commit sha instead of main reference

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -23,9 +23,6 @@ bitnami/render-template:
 bitnami/ini-file:
   - source: workflows/
     dest: .github/workflows/
-bitnami/bndiagnostic:
-  - source: workflows/
-    dest: .github/workflows/
 bitnami/bncert:
   - source: workflows/
     dest: .github/workflows/

--- a/workflows/comments.yml
+++ b/workflows/comments.yml
@@ -17,5 +17,5 @@ concurrency:
 jobs:
   call-comments-workflow:
     if: ${{ github.repository_owner == 'bitnami' }}
-    uses: bitnami/support/.github/workflows/comment-created.yml@main
+    uses: bitnami/support/.github/workflows/comment-created.yml@96bc169b45aa483cf2bafaaee9dae80eabd96cac
     secrets: inherit

--- a/workflows/move-closed-issues.yml
+++ b/workflows/move-closed-issues.yml
@@ -19,5 +19,5 @@ concurrency:
 jobs:
   call-move-closed-workflow:
     if: ${{ github.repository_owner == 'bitnami' }}
-    uses: bitnami/support/.github/workflows/item-closed.yml@main
+    uses: bitnami/support/.github/workflows/item-closed.yml@96bc169b45aa483cf2bafaaee9dae80eabd96cac
     secrets: inherit

--- a/workflows/pr-review-hack.yml
+++ b/workflows/pr-review-hack.yml
@@ -50,7 +50,7 @@ jobs:
           echo "labels=${labels}" >> $GITHUB_OUTPUT
           echo "resource_url=${resource_url}" >> $GITHUB_OUTPUT
   call-pr-review-comment:
-    uses: bitnami/support/.github/workflows/pr-review-comment.yml@main
+    uses: bitnami/support/.github/workflows/pr-review-comment.yml@96bc169b45aa483cf2bafaaee9dae80eabd96cac
     needs: pr-info
     permissions:
       contents: read

--- a/workflows/pr-reviews-requested.yml
+++ b/workflows/pr-reviews-requested.yml
@@ -16,5 +16,5 @@ concurrency:
 jobs:
   call-pr-review-workflow:
     if: ${{ github.repository_owner == 'bitnami' }}
-    uses: bitnami/support/.github/workflows/pr-review-requested-sync.yml@main
+    uses: bitnami/support/.github/workflows/pr-review-requested-sync.yml@96bc169b45aa483cf2bafaaee9dae80eabd96cac
     secrets: inherit

--- a/workflows/reasign.yml
+++ b/workflows/reasign.yml
@@ -20,5 +20,5 @@ concurrency:
 jobs:
   call-reasign-workflow:
     if: ${{ github.repository_owner == 'bitnami' }}
-    uses: bitnami/support/.github/workflows/item-labeled.yml@main
+    uses: bitnami/support/.github/workflows/item-labeled.yml@96bc169b45aa483cf2bafaaee9dae80eabd96cac
     secrets: inherit

--- a/workflows/triage.yml
+++ b/workflows/triage.yml
@@ -23,5 +23,5 @@ concurrency:
 jobs:
   call-triage-workflow:
     if: ${{ github.repository_owner == 'bitnami' }}
-    uses: bitnami/support/.github/workflows/item-opened.yml@main
+    uses: bitnami/support/.github/workflows/item-opened.yml@96bc169b45aa483cf2bafaaee9dae80eabd96cac
     secrets: inherit


### PR DESCRIPTION
ai-assisted=no

### Description of the change

Use commit sha instead of main to call shared workflows.
Remove `bndiagnostic` from synced repositories (that repository is currently archived).

### Benefits

Shared workflows inherits all secrets, if this repository is compromised, all the secrets from the repositories using these workflows could be exposed. With these changes we avoid the problem.

### Possible drawbacks

None

### Additional information

From maintenance perspective this could be a pain in the ass, but the [sync worklfow](https://github.com/bitnami/support/actions/workflows/sync-support-workflows.yml) will help us to keep all dependant repositories synchronised (that workflow will create PRs with the changes in all dependant repositories)